### PR TITLE
feat: add codetrail config list command

### DIFF
--- a/codetrail/__main__.py
+++ b/codetrail/__main__.py
@@ -4,12 +4,10 @@ import sys
 
 from codetrail import cli
 from codetrail import parsers
-from codetrail.conf import LOGGER
 
 
 def main() -> None:
     """Entrypoint for the version control system."""
-    LOGGER.info("Welcome to codetrail!")
     args = parsers.arg_parser.parse_args(sys.argv[1:])
     cli.run(args.command, args)
 

--- a/codetrail/cli.py
+++ b/codetrail/cli.py
@@ -36,7 +36,6 @@ def init(arguments: argparse.Namespace) -> None:
     Args:
         arguments: Parsed command-line arguments containing the target path.
     """
-    LOGGER.info("Initializing a new repository.")
     try:
         command = commands.InitializeRepository(path=arguments.path)
         cmd_init.initialize_repository(command)
@@ -72,6 +71,9 @@ def run_config(arguments: argparse.Namespace) -> None:
         case "get":
             command = commands.GetConfig(key=arguments.key[0])
             cmd_config.get_config(command)
+        case "list":
+            command = commands.ListConfig()
+            cmd_config.list_config(command)
         case _:
-            msg = f"Invalid Command '{arguments.command}'. Choose from (set,)"
+            msg = f"Invalid Command '{arguments.command}'. Choose from (set,get)"
             raise exceptions.InvalidCommandError(msg)

--- a/codetrail/cmd_config.py
+++ b/codetrail/cmd_config.py
@@ -28,16 +28,16 @@ def set_config(command: commands.SetConfig) -> None:
     repository = models.CodetrailRepository(repo_path)
 
     if command.section not in CONFIG_SECTIONS:
-        msg = f"Invalid section '{command.section}'!, choose from '{CONFIG_SECTIONS}'"
+        msg = f"Invalid section '{command.section}', choose from '{CONFIG_SECTIONS}'"
         raise exceptions.UnsupportedConfigError(msg)
 
     if command.section in CONFIG_SECTIONS and command.option not in CONFIG_USER_OPTIONS:
-        msg = f"Invalid option '{command.option}'!, choose from '{CONFIG_USER_OPTIONS}'"
+        msg = f"Invalid option '{command.option}', choose from '{CONFIG_USER_OPTIONS}'"
         raise exceptions.UnsupportedConfigError(msg)
 
     repository.config.set(command.section, command.option, command.value)
     utils.write_to_config_file(repository.config_path, repository.config)
-    LOGGER.info(f"Set value '{command.value}' on key '{command.key}'.")
+    LOGGER.info(f"{command.key} = {command.value}")
 
 
 def get_config(command: commands.GetConfig) -> None:
@@ -55,10 +55,28 @@ def get_config(command: commands.GetConfig) -> None:
     try:
         value = repository.config.get(command.section, command.option)
     except configparser.NoSectionError as e:
-        msg = f"Invalid section '{command.section}'!, choose from '{CONFIG_SECTIONS}'"
+        msg = f"Invalid section '{command.section}', choose from '{CONFIG_SECTIONS}'"
         raise exceptions.UnsupportedConfigError(msg) from e
     except configparser.NoOptionError as e:
         msg = f"Option '{command.option}' not found in section '{command.section}'"
         raise exceptions.UnsupportedConfigError(msg) from e
     else:
         LOGGER.info(f"{value}")
+
+
+def list_config(command: commands.ListConfig) -> None:
+    """List all configuration values.
+
+    This function lists all configuration values from the repository configuration file.
+    in the format: section.option = value
+
+    Args:
+        command: The command responsible for listing all config values.
+    """
+    repo_path = utils.find_repository_path(command.default_path) or command.default_path
+    repository = models.CodetrailRepository(repo_path)
+
+    for section in repository.config.sections():
+        for option in repository.config.options(section):
+            value = repository.config.get(section, option)
+            LOGGER.info(f"{section}.{option} = {value}")

--- a/codetrail/commands.py
+++ b/codetrail/commands.py
@@ -95,3 +95,13 @@ class GetConfig(BaseConfigCommand):
     Attributes:
         key (str): The key to get the value from.
     """
+
+
+class ListConfig(BaseConfigCommand):
+    """Command to list all configuration values.
+
+    Attributes:
+        None: This command has no specific attributes.
+    """
+
+    key: str = ""

--- a/codetrail/conf.py
+++ b/codetrail/conf.py
@@ -3,12 +3,42 @@
 from __future__ import annotations
 
 import logging
+import sys
 from typing import Final
 
-LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
+
+class CodetrailFormatter(logging.Formatter):
+    """Custom formatter for Codetrail logs."""
+
+    log_format: str = "%(message)s"
+    red: str = "\033[1;31m"
+    green: str = "\033[1;32m"
+    yellow: str = "\033[1;33m"
+    reset: str = "\033[1;0m"
+
+    FORMATS = {
+        logging.INFO: f"{green}{log_format}{reset}",
+        logging.WARNING: f"{yellow}{log_format}{reset}",
+        logging.ERROR: f"{red}{log_format}{reset}",
+    }
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record.
+
+        Returns:
+            str: The formatted log record.
+        """
+        log_format = self.FORMATS.get(record.levelno)
+        formatter = logging.Formatter(log_format)
+        return formatter.format(record)
+
+
 LOGGER: Final = logging.getLogger("codetrail")
 LOGGER.setLevel(level=logging.INFO)
+handler = logging.StreamHandler(stream=sys.stdout)
+handler.setFormatter(CodetrailFormatter())
+handler.setLevel(level=logging.INFO)
+LOGGER.addHandler(handler)
 
 DEFAULT_CODETRAIL_DIRECTORY = ".codetrail"
 DEFAULT_REPOSITORY_DESCRIPTION = (

--- a/codetrail/parsers.py
+++ b/codetrail/parsers.py
@@ -30,6 +30,7 @@ config = arg_subparsers.add_parser(
 config_subparsers = config.add_subparsers(title="Commands", dest="command")
 config_subparsers.required = True
 
+# ~ Set
 set_ = config_subparsers.add_parser("set", help="Set a config value")
 set_.add_argument(
     "key",
@@ -45,12 +46,14 @@ set_.add_argument(
     type=str,
     nargs=1,
 )
-
-get_ = config_subparsers.add_parser("get", help="Get a config value")
-get_.add_argument(
+# ~ Get
+get = config_subparsers.add_parser("get", help="Get a config value")
+get.add_argument(
     "key",
     metavar="key",
     help="The name of the key that holds the configuration value.",
     type=str,
     nargs=1,
 )
+# ~ List
+list_ = config_subparsers.add_parser("list", help="List all config values")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,7 @@ class TestConfig:
             )
 
     def test_calls_get_config(self, temporary_dir):
-        """Test valid setting of the configuration."""
+        """Test getting of the configuration value."""
         arguments = argparse.Namespace(
             command="get",
             key=["user.name"],
@@ -82,6 +82,13 @@ class TestConfig:
             mock_get_config.assert_called_once_with(
                 commands.GetConfig(key=arguments.key[0])
             )
+
+    def test_calls_list_config(self, temporary_dir):
+        """Test listing of the configuration."""
+        arguments = argparse.Namespace(command="list")
+        with patch.object(cmd_config, "list_config") as mock_get_config:
+            cli.config(arguments)
+            mock_get_config.assert_called_once_with(commands.ListConfig())
 
     def test_raises_exception_on_wrong_command(self, argument_namespace):
         """Test with wrong command."""

--- a/tests/test_cmd_config.py
+++ b/tests/test_cmd_config.py
@@ -3,7 +3,7 @@ import pytest
 
 from codetrail import commands
 from codetrail import exceptions
-from codetrail.cmd_config import get_config, set_config
+from codetrail.cmd_config import get_config, list_config, set_config
 
 
 def initialize_repository_command(path):
@@ -76,3 +76,16 @@ class TestGetConfig:
         """Test with wrong option."""
         with pytest.raises(exceptions.UnsupportedConfigError):
             get_config(commands.GetConfig(key="user.names"))
+
+
+@pytest.mark.usefixtures("default_path")
+class TestListConfig:
+    """Tests for `list_config` function."""
+
+    def test_can_get_name_for_a_user(self, code_repository, config_parser, caplog):
+        """Test gets user name from config."""
+        set_config(commands.SetConfig(key="user.name", value="Chill Guy"))
+
+        with caplog.at_level(logging.INFO):
+            list_config(commands.ListConfig(key="user.name"))
+            assert "user.name = Chill Guy" in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,10 +7,9 @@ from unittest.mock import patch
 from codetrail.__main__ import main  # noqa: PLC2701
 
 
-def test_main_logs_message(caplog):
+def test_main_logs_message():
     """Test that main logs a welcome message."""
     with (
-        caplog.at_level(logging.INFO),
         patch("sys.argv", ["codetrail", "init", "/some/path"]),
         patch("codetrail.__main__.parsers.arg_parser.parse_args") as mock_parser,
         patch("codetrail.__main__.cli.run") as mock_match_commands,
@@ -24,5 +23,3 @@ def test_main_logs_message(caplog):
 
         mock_parser.assert_called_once_with(["init", "/some/path"])
         mock_match_commands.assert_called_once_with("init", mock_args)
-
-        assert "Welcome to codetrail!" in caplog.text


### PR DESCRIPTION
This PR implements the git config list command.

## List
- adds `git config list` command

## Misc
- Adds custom formatter, `CodetrailFormatter` that supports coloring logs