### PR TITLE
feat: add codetrail config unset and edit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ We believe in learning by doing, but also in documenting why we did what we did.
 Current RFCs:
 
 - [RFC-001: Codetrail Initialize Command](docs/rfcs/CODETRAIL001.md)
+- [RFC-010: Codetrail Configuration Command](docs/rfcs/CODETRAIL010.md)
 - More to come as we build this thing!
 
 Want to contribute a new feature? Start by reading our existing RFCs to understand our design philosophy, then draft your own RFC before diving into code. We promise to read it, even if it's written on a napkin (digital napkins preferred).
@@ -39,7 +40,7 @@ Want to contribute a new feature? Start by reading our existing RFCs to understa
 
 - [x] Project setup (You're looking at it!)
 - [x] `init` - Because every journey needs a starting point. ([CODETRAIL001](docs/rfcs/CODETRAIL001.md))
-- [ ] `config` - Local config only (we're keeping it simple, folks)
+- [x] `config` - Local config only (we're keeping it simple, folks) ([CODETRAIL010](docs/rfcs/CODETRAIL010.md))
 - [ ] `add` - Teaching `codetrail` which files to track
 - [ ] `commit` - Making our first memories together
 

--- a/codetrail/cli.py
+++ b/codetrail/cli.py
@@ -21,12 +21,10 @@ def run(command: str, arguments: argparse.Namespace) -> None:
     """
     if command == "init":
         init(arguments)
-
     elif command in {"set", "unset", "get", "list", "edit"}:
         config(arguments)
-
     else:
-        msg = f"Invalid Command '{command}'. Choose from (init,config)"
+        msg = f"Invalid Command '{command}'"
         raise exceptions.InvalidCommandError(msg)
 
 
@@ -66,14 +64,19 @@ def run_config(arguments: argparse.Namespace) -> None:
     """
     match arguments.command:
         case "set":
-            command = commands.SetConfig(key=arguments.key[0], value=arguments.value[0])
-            cmd_config.set_config(command)
+            cmd_config.set_config(
+                commands.SetConfig(key=arguments.key[0], value=arguments.value[0]),
+            )
         case "get":
-            command = commands.GetConfig(key=arguments.key[0])
-            cmd_config.get_config(command)
+            cmd_config.get_config(commands.GetConfig(key=arguments.key[0]))
         case "list":
-            command = commands.ListConfig()
-            cmd_config.list_config(command)
+            cmd_config.list_config(commands.ListConfig())
+        case "unset":
+            cmd_config.unset_config(commands.UnsetConfig(key=arguments.key[0]))
+        case "edit":
+            cmd_config.set_config(
+                commands.SetConfig(key=arguments.key[0], value=arguments.value[0]),
+            )
         case _:
-            msg = f"Invalid Command '{arguments.command}'. Choose from (set,get)"
+            msg = f"Invalid Command '{arguments.command}'"
             raise exceptions.InvalidCommandError(msg)

--- a/codetrail/commands.py
+++ b/codetrail/commands.py
@@ -105,3 +105,11 @@ class ListConfig(BaseConfigCommand):
     """
 
     key: str = ""
+
+
+class UnsetConfig(BaseConfigCommand):
+    """Command to unset a configuration value with key.
+
+    Attributes:
+        key (str): The key to unset the value from.
+    """

--- a/codetrail/parsers.py
+++ b/codetrail/parsers.py
@@ -57,3 +57,28 @@ get.add_argument(
 )
 # ~ List
 list_ = config_subparsers.add_parser("list", help="List all config values")
+# ~ Unset
+unset = config_subparsers.add_parser("unset", help="Unset a config value")
+unset.add_argument(
+    "key",
+    metavar="key",
+    help="The name of the key that holds the configuration value.",
+    type=str,
+    nargs=1,
+)
+# ~ Edit
+edit = config_subparsers.add_parser("edit", help="Edit the config file.")
+edit.add_argument(
+    "key",
+    metavar="key",
+    help="The name of the key that will hold the configuration value.",
+    type=str,
+    nargs=1,
+)
+edit.add_argument(
+    "value",
+    metavar="value",
+    help="The new value of the configuration setting.",
+    type=str,
+    nargs=1,
+)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 
 import pytest
 
-from codetrail import cli, cmd_config, cmd_init
+from codetrail import cli
+from codetrail import cmd_config
+from codetrail import cmd_init
 from codetrail import commands
 from codetrail import exceptions
 
@@ -80,15 +82,40 @@ class TestConfig:
         with patch.object(cmd_config, "get_config") as mock_get_config:
             cli.config(arguments)
             mock_get_config.assert_called_once_with(
-                commands.GetConfig(key=arguments.key[0])
+                commands.GetConfig(key=arguments.key[0]),
             )
 
     def test_calls_list_config(self, temporary_dir):
         """Test listing of the configuration."""
         arguments = argparse.Namespace(command="list")
-        with patch.object(cmd_config, "list_config") as mock_get_config:
+        with patch.object(cmd_config, "list_config") as mock_list_config:
             cli.config(arguments)
-            mock_get_config.assert_called_once_with(commands.ListConfig())
+            mock_list_config.assert_called_once_with(commands.ListConfig())
+
+    def test_calls_unset_config(self, temporary_dir):
+        """Test removing of the configuration value."""
+        arguments = argparse.Namespace(
+            command="unset",
+            key=["user.name"],
+        )
+        with patch.object(cmd_config, "unset_config") as mock_unset_config:
+            cli.config(arguments)
+            mock_unset_config.assert_called_once_with(
+                commands.UnsetConfig(key=arguments.key[0]),
+            )
+
+    def test_calls_edit_config(self, temporary_dir):
+        """Test valid editing of the configuration."""
+        arguments = argparse.Namespace(
+            command="edit",
+            key=["user.name"],
+            value=["Chill Guy"],
+        )
+        with patch.object(cmd_config, "set_config") as mock_set_config:
+            cli.config(arguments)
+            mock_set_config.assert_called_once_with(
+                commands.SetConfig(key=arguments.key[0], value=arguments.value[0]),
+            )
 
     def test_raises_exception_on_wrong_command(self, argument_namespace):
         """Test with wrong command."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 """Tests for main entrypoint."""
 
-import logging
 from unittest.mock import MagicMock
 from unittest.mock import patch
 


### PR DESCRIPTION
This PR implements the git config unset and edit commands.

## Commands
- adds `git config unset <key>` command
- adds `git config edit <key> <new value>` command